### PR TITLE
More robust tests and indexes fixes

### DIFF
--- a/fotos/common/invokeGetIndex.ts
+++ b/fotos/common/invokeGetIndex.ts
@@ -9,17 +9,21 @@ import {
   IIndex, ITraceMeta,
 } from "../types";
 
-export function getInvokeGetIndexParams(ctx: ITraceMeta): InvocationRequest {
+export function getInvokeGetIndexParams(traceMeta: ITraceMeta): InvocationRequest {
   return {
-    ClientContext: JSON.stringify({ custom: ctx}),
     FunctionName: `${process.env.LAMBDA_PREFIX}indexes`,
     InvocationType: INVOCATION_REQUEST_RESPONSE,
     LogType: "Tail",
+    Payload: JSON.stringify({
+      body: JSON.stringify({
+        traceMeta,
+      }),
+    }),
   };
 }
 
-export default function invokeGetIndex(ctx: ITraceMeta) {
-  const params = getInvokeGetIndexParams(ctx);
+export default function invokeGetIndex(traceMeta: ITraceMeta) {
+  const params = getInvokeGetIndexParams(traceMeta);
   return lambda.invoke(params).promise()
     .then((invocationResponse: InvocationResponse) => {
       try {

--- a/fotos/common/invokeGetIndex.ts
+++ b/fotos/common/invokeGetIndex.ts
@@ -1,0 +1,37 @@
+import {
+  InvocationRequest,
+  InvocationResponse,
+} from "aws-sdk/clients/lambda";
+import { JSONParseError } from "../errors/jsonParse";
+import { INVOCATION_REQUEST_RESPONSE } from "../lib/constants";
+import lambda from "../lib/lambda";
+import {
+  IIndex, ITraceMeta,
+} from "../types";
+
+export function getInvokeGetIndexParams(ctx: ITraceMeta): InvocationRequest {
+  return {
+    ClientContext: JSON.stringify(ctx),
+    FunctionName: `${process.env.LAMBDA_PREFIX}indexes`,
+    InvocationType: INVOCATION_REQUEST_RESPONSE,
+    LogType: "Tail",
+  };
+}
+
+export default function invokeGetIndex(ctx: ITraceMeta) {
+  const params = getInvokeGetIndexParams(ctx);
+  return lambda.invoke(params).promise()
+    .then((invocationResponse: InvocationResponse) => {
+      try {
+        const payload = JSON.parse(invocationResponse.Payload as string);
+        const peopleObject: IIndex = typeof payload === "object" ? JSON.parse(payload.body) : { tags: {}, people: {} };
+        return peopleObject;
+      } catch (e) {
+        // tslint:disable-next-line:max-line-length
+        throw new JSONParseError(e, `invokeGetIndex invocationResponse is : ${JSON.stringify(invocationResponse)}`);
+      }
+    })
+    .catch((e) => {
+      throw new JSONParseError(e, "invokeGetIndex");
+    });
+}

--- a/fotos/common/invokeGetIndex.ts
+++ b/fotos/common/invokeGetIndex.ts
@@ -11,7 +11,7 @@ import {
 
 export function getInvokeGetIndexParams(ctx: ITraceMeta): InvocationRequest {
   return {
-    ClientContext: JSON.stringify(ctx),
+    ClientContext: JSON.stringify({ custom: ctx}),
     FunctionName: `${process.env.LAMBDA_PREFIX}indexes`,
     InvocationType: INVOCATION_REQUEST_RESPONSE,
     LogType: "Tail",

--- a/fotos/common/invokePutIndex.ts
+++ b/fotos/common/invokePutIndex.ts
@@ -1,0 +1,27 @@
+import {
+  InvocationRequest,
+} from "aws-sdk/clients/lambda";
+import { INVOCATION_EVENT } from "../lib/constants";
+import lambda from "../lib/lambda";
+import {
+  IIndex,
+} from "../types";
+
+export function getInvokeUpdateParams(body: IIndex, traceMeta): InvocationRequest {
+  return {
+    FunctionName: `${process.env.LAMBDA_PREFIX}indexes`,
+    InvocationType: INVOCATION_EVENT,
+    LogType: "Tail",
+    Payload: JSON.stringify({
+      body: JSON.stringify({
+        index: body,
+        traceMeta,
+      }),
+    }),
+  };
+}
+
+export default function invokePutIndex(body: IIndex, traceMeta) {
+  const params = getInvokeUpdateParams(body, traceMeta);
+  return lambda.invoke(params).promise();
+}

--- a/fotos/common/invokePutIndex.ts
+++ b/fotos/common/invokePutIndex.ts
@@ -9,7 +9,7 @@ import {
 
 export function getInvokeUpdateParams(body: IIndex, traceMeta): InvocationRequest {
   return {
-    FunctionName: `${process.env.LAMBDA_PREFIX}indexes`,
+    FunctionName: `${process.env.LAMBDA_PREFIX}indexesUpdate`,
     InvocationType: INVOCATION_EVENT,
     LogType: "Tail",
     Payload: JSON.stringify({

--- a/fotos/faces.ts
+++ b/fotos/faces.ts
@@ -30,6 +30,7 @@ import {
   IPathParameters,
   IPerson,
   IPersonMatch,
+  ITraceMeta,
   IUpdateBody,
 } from "./types";
 
@@ -222,13 +223,18 @@ export function getUpdatePathParameters(newImage: IImage): IPathParameters {
   };
 }
 
-export function getInvokeUpdateParams(pathParameters: IPathParameters, body: IUpdateBody): InvocationRequest {
+export function getInvokeUpdateParams(
+  pathParameters: IPathParameters, body: IUpdateBody, traceMeta: ITraceMeta,
+): InvocationRequest {
   return {
     FunctionName: `${process.env.LAMBDA_PREFIX}update`,
     InvocationType: INVOCATION_REQUEST_RESPONSE,
     LogType: "Tail",
     Payload: JSON.stringify({
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        body,
+        traceMeta,
+      }),
       pathParameters,
     }),
   };
@@ -291,7 +297,9 @@ export async function addToPerson(event: APIGatewayProxyEvent, context: Context,
     await invokePutPeople(updatedPeople, getTraceMeta(logBaseParams));
     const pathParameters: IPathParameters = getUpdatePathParameters(newImage);
     const updateBody: IUpdateBody = getUpdateBody(facesWithPeople, newPeopleThatAreOkSize);
-    const updateParams: InvocationRequest = getInvokeUpdateParams(pathParameters, updateBody);
+    const updateParams: InvocationRequest = getInvokeUpdateParams(
+      pathParameters, updateBody, getTraceMeta(logBaseParams),
+    );
     await lambda.invoke(updateParams).promise();
     const logMetaParams: ILoggerFacesParams = {
       existingPeople,

--- a/fotos/faces.ts
+++ b/fotos/faces.ts
@@ -226,15 +226,16 @@ export function getUpdatePathParameters(newImage: IImage): IPathParameters {
 export function getInvokeUpdateParams(
   pathParameters: IPathParameters, body: IUpdateBody, traceMeta: ITraceMeta,
 ): InvocationRequest {
+  const bodyWithMeta: IUpdateBody = {
+    ...body,
+    traceMeta,
+  };
   return {
     FunctionName: `${process.env.LAMBDA_PREFIX}update`,
     InvocationType: INVOCATION_REQUEST_RESPONSE,
     LogType: "Tail",
     Payload: JSON.stringify({
-      body: JSON.stringify({
-        body,
-        traceMeta,
-      }),
+      body: JSON.stringify(bodyWithMeta),
       pathParameters,
     }),
   };

--- a/fotos/faces__test__.ts
+++ b/fotos/faces__test__.ts
@@ -479,7 +479,7 @@ test("getUpdateBody - no people", (t) => {
   faces.getPeopleForFaces(newImage, existingPeople, mockFaceMatcher)
     .then((facesWithPeople) => {
       const result = faces.getUpdateBody(facesWithPeople, new Array<IPerson>());
-      t.equal(result.people.length, 0, "passes joi validation but has 0 results, as none over threshold");
+      t.equal(result.people!.length, 0, "has 0 results, as none over threshold");
       t.end();
     })
     .catch(t.fail);
@@ -523,7 +523,7 @@ test("getUpdateBody - unique people", (t) => {
     userIdentityId: "some-str",
   }];
   const result = faces.getUpdateBody(facesWithPeople, newPeople);
-  t.equal(result.people.length, 1);
+  t.equal(result.people!.length, 1);
   t.deepEqual(result.people, [person.id], "dedupes person ids");
   t.end();
 });

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -140,8 +140,8 @@ export async function putItem(event: APIGatewayProxyEvent, context: Context, cal
 
   try {
     const indexesClean = removeZeroCounts(requestBody.index);
-    const putIndexObject: PutObjectOutput = await putIndex(requestBody.index);
-    logger(context, loggerBaseParams, getLogFields(requestBody.index));
+    const putIndexObject: PutObjectOutput = await putIndex(indexesClean);
+    logger(context, loggerBaseParams, getLogFields(indexesClean));
     return callback(null, success(requestBody));
   } catch (err) {
     logger(context, loggerBaseParams, { err, ...getLogFields(requestBody.index)});

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -78,9 +78,8 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
     context.clientContext.Custom ?
     JSON.parse(context.clientContext.Custom) :
     null ;
-
   // tslint:disable-next-line:no-console
-  console.log("client context", context.clientContext);
+  console.log("client context", context.clientContext, event);
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),
     name: "getItem",

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -74,12 +74,9 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
   const startTime: number = Date.now();
   s3 = createS3Client();
   const s3Params: GetObjectRequest = getS3Params();
-  const traceMeta: ITraceMeta | null  = context.clientContext &&
-    context.clientContext.Custom ?
-    JSON.parse(context.clientContext.Custom) :
-    null ;
-  // tslint:disable-next-line:no-console
-  console.log("client context - custom?", context);
+  const eventBody = event.body ? JSON.parse(event.body) : null;
+  const traceMeta: ITraceMeta | undefined = eventBody!.traceMeta;
+
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),
     name: "getItem",

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -26,7 +26,7 @@ export function getS3Params(): GetObjectRequest {
 }
 
 export function getZeroCount(indexObj: IIndexDictionary): number {
-  return Object.keys(indexObj).filter((item) => +item <= 0).length;
+  return Object.keys(indexObj).filter((item) => indexObj[item] <= 0).length;
 }
 
 export function getObject(s3Params: GetObjectRequest): Promise<IIndex> {

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -79,7 +79,7 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
     JSON.parse(context.clientContext.Custom) :
     null ;
   // tslint:disable-next-line:no-console
-  console.log("client context", context, event);
+  console.log("client context", context);
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),
     name: "getItem",

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -79,7 +79,7 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
     JSON.parse(context.clientContext.Custom) :
     null ;
   // tslint:disable-next-line:no-console
-  console.log("client context", context.clientContext, event);
+  console.log("client context", context, event);
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),
     name: "getItem",

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -1,17 +1,20 @@
 
 import { APIGatewayProxyEvent, Callback, Context } from "aws-lambda";
 import { S3 } from "aws-sdk/clients/all";
-import { GetObjectRequest } from "aws-sdk/clients/s3";
+import { GetObjectRequest, PutObjectOutput } from "aws-sdk/clients/s3";
 import * as uuid from "uuid";
 import getS3Bucket from "./common/getS3Bucket";
+import { getS3PutParams } from "./common/getS3PutParams";
 import { failure, success } from "./common/responses";
 import { JSONParseError } from "./errors/jsonParse";
 import { INDEXES_KEY } from "./lib/constants";
 import logger from "./lib/logger";
 import createS3Client from "./lib/s3";
 import {
-  IIndex, IIndexDictionary, ILoggerBaseParams,
+  IIndex, IIndexDictionary, ILoggerBaseParams, IPutIndexRequest,
 } from "./types";
+
+let s3: S3;
 
 export function getS3Params(): GetObjectRequest {
   const Bucket = getS3Bucket();
@@ -26,7 +29,7 @@ export function getZeroCount(indexObj: IIndexDictionary): number {
   return Object.keys(indexObj).filter((item) => +item <= 0).length;
 }
 
-export function getObject(s3: S3, s3Params: GetObjectRequest): Promise<IIndex> {
+export function getObject(s3Params: GetObjectRequest): Promise<IIndex> {
   return s3.getObject(s3Params)
     .promise()
     .then((s3Object) => {
@@ -70,7 +73,7 @@ export function getLogFields(indexesObj: IIndex) {
 
 export async function getItem(event: APIGatewayProxyEvent, context: Context, callback: Callback): Promise<void> {
   const startTime: number = Date.now();
-  const s3: S3 = createS3Client();
+  s3 = createS3Client();
   const s3Params: GetObjectRequest = getS3Params();
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),
@@ -80,11 +83,45 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
     traceId: uuid.v1(),
   };
   try {
-    const indexesObject: IIndex = await getObject(s3, s3Params);
+    const indexesObject: IIndex = await getObject(s3Params);
     logger(context, loggerBaseParams, getLogFields(indexesObject));
     return callback(null, success(indexesObject));
   } catch (err) {
     logger(context, loggerBaseParams, { err });
+    return callback(null, failure(err));
+  }
+}
+
+export function putIndex(index: IIndex): Promise<PutObjectOutput> {
+  const s3PutParams = getS3PutParams(index, INDEXES_KEY);
+  return s3.putObject(s3PutParams).promise();
+}
+
+export async function putItem(event: APIGatewayProxyEvent, context: Context, callback: Callback): Promise<void> {
+  const startTime: number = Date.now();
+
+  const requestBody: IPutIndexRequest = event.body ? JSON.parse(event.body) : { index: {
+    people: {},
+    tags: {},
+  }};
+  const traceMeta = requestBody!.traceMeta;
+
+  s3 = createS3Client();
+
+  const loggerBaseParams: ILoggerBaseParams = {
+    id: uuid.v1(),
+    name: "putItem",
+    parentId: traceMeta && traceMeta!.parentId || "",
+    startTime,
+    traceId: traceMeta && traceMeta!.traceId || uuid.v1(),
+  };
+
+  try {
+    const putIndexObject: PutObjectOutput = await putIndex(requestBody.index);
+    logger(context, loggerBaseParams, getLogFields(requestBody.index));
+    return callback(null, success(requestBody));
+  } catch (err) {
+    logger(context, loggerBaseParams, { err, ...getLogFields(requestBody.index)});
     return callback(null, failure(err));
   }
 }

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -99,6 +99,29 @@ export function putIndex(index: IIndex): Promise<PutObjectOutput> {
   return s3.putObject(s3PutParams).promise();
 }
 
+export function removeZeroCounts(index: IIndex): IIndex {
+  const people: IIndexDictionary = Object.keys(index.people).reduce((accum, key) => {
+    return index.people[key] > 0 ?
+      {
+        ...accum,
+        [key]: index.people[key],
+      } :
+      accum;
+  }, {} as IIndexDictionary);
+  const tags: IIndexDictionary = Object.keys(index.tags).reduce((accum, key) => {
+    return index.tags[key] > 0 ?
+      {
+        ...accum,
+        [key]: index.tags[key],
+      } :
+      accum;
+  }, {} as IIndexDictionary);
+  return {
+    people,
+    tags,
+  };
+}
+
 export async function putItem(event: APIGatewayProxyEvent, context: Context, callback: Callback): Promise<void> {
   const startTime: number = Date.now();
 
@@ -116,6 +139,7 @@ export async function putItem(event: APIGatewayProxyEvent, context: Context, cal
   };
 
   try {
+    const indexesClean = removeZeroCounts(requestBody.index);
     const putIndexObject: PutObjectOutput = await putIndex(requestBody.index);
     logger(context, loggerBaseParams, getLogFields(requestBody.index));
     return callback(null, success(requestBody));

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -75,7 +75,7 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
   s3 = createS3Client();
   const s3Params: GetObjectRequest = getS3Params();
   const eventBody = event.body ? JSON.parse(event.body) : null;
-  const traceMeta: ITraceMeta | undefined = eventBody!.traceMeta;
+  const traceMeta: ITraceMeta | undefined = eventBody && eventBody.traceMeta;
 
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),

--- a/fotos/indexes.ts
+++ b/fotos/indexes.ts
@@ -79,7 +79,7 @@ export async function getItem(event: APIGatewayProxyEvent, context: Context, cal
     JSON.parse(context.clientContext.Custom) :
     null ;
   // tslint:disable-next-line:no-console
-  console.log("client context", context);
+  console.log("client context - custom?", context);
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),
     name: "getItem",

--- a/fotos/indexes__test__.ts
+++ b/fotos/indexes__test__.ts
@@ -1,0 +1,21 @@
+import * as test from "tape";
+import * as indexes from "./indexes";
+import { IIndex } from "./types";
+
+test("removeZeroCounts ", (t) => {
+  const index: IIndex = {
+    people: {
+      emma: 1,
+      leona: 1,
+      wilma: 2,
+    },
+    tags: {
+      black: 0,
+      pink: 2,
+      yellow: 1,
+    },
+  };
+  const result = indexes.removeZeroCounts(index);
+  t.equal(result.tags.black, undefined, "0 index has been removed");
+  t.end();
+});

--- a/fotos/stream.ts
+++ b/fotos/stream.ts
@@ -157,7 +157,7 @@ export async function indexRecords(event: DynamoDBStreamEvent, context: Context,
     traceId: uuid.v1(),
   };
   try {
-    const existingIndex: IIndex = await invokeGetIndex(getTraceMeta(loggerBaseParams) );
+    const existingIndex: IIndex = await invokeGetIndex(getTraceMeta(loggerBaseParams));
     const updatedIndexes: IIndex = getUpdatedIndexes(existingIndex, event.Records);
     const response: InvocationResponse = await invokePutIndex(updatedIndexes, getTraceMeta(loggerBaseParams));
     logger(context, loggerBaseParams, getLogFields(event.Records, existingIndex, updatedIndexes));

--- a/fotos/stream.ts
+++ b/fotos/stream.ts
@@ -132,9 +132,17 @@ export function getModifiedIndexItems(existing: IIndexDictionary, updated: IInde
   });
 }
 
+export function getFirstRecord(records: DynamoDBRecord[]) {
+  const firstRecord: DynamoDBRecord = records[0];
+  return firstRecord.dynamodb!.NewImage ?
+    ddbAttVals.unwrap(records[0].dynamodb!.NewImage) :
+    ddbAttVals.unwrap(records[0].dynamodb!.OldImage);
+}
+
 export function getLogFields(records: DynamoDBRecord[], existingIndex?: IIndex, updatedIndexes?: IIndex) {
-  const firstRecord = ddbAttVals.unwrap(records[0].dynamodb!.NewImage);
+  const firstRecord = getFirstRecord(records);
   return {
+    ddbEventName: records[0].eventName,
     ddbEventRecordsCount: safeLength(records),
     ddbEventRecordsRaw: records,
     imageBirthtime: firstRecord.birthtime,

--- a/fotos/stream.ts
+++ b/fotos/stream.ts
@@ -152,9 +152,9 @@ export function getLogFields(records: DynamoDBRecord[], existingIndex?: IIndex, 
     imageUsername: firstRecord.username,
     imageWidth: firstRecord.meta && firstRecord.meta.width,
     indexesModifiedPeopleCount: existingIndex && updatedIndexes &&
-      getModifiedIndexItems(existingIndex.people, updatedIndexes.people),
+      getModifiedIndexItems(existingIndex.people, updatedIndexes.people).length,
     indexesModifiedTagCount: existingIndex && updatedIndexes &&
-      getModifiedIndexItems(existingIndex.tags, updatedIndexes.tags),
+      getModifiedIndexItems(existingIndex.tags, updatedIndexes.tags).length,
     indexesPeopleCount: existingIndex && Object.keys(existingIndex.people).length,
     indexesTagCount: existingIndex && Object.keys(existingIndex.tags).length,
     indexesUpdatedPeopleCount: updatedIndexes && Object.keys(updatedIndexes.people).length,

--- a/fotos/stream.ts
+++ b/fotos/stream.ts
@@ -23,7 +23,7 @@ import { safeLength } from "./create";
 import { JSONParseError } from "./errors/jsonParse";
 import { getZeroCount } from "./indexes";
 import {
-  IIndex, IIndexFields, ILoggerBaseParams,
+  IIndex, IIndexDictionary, IIndexFields, ILoggerBaseParams,
 } from "./types";
 
 let s3: S3;
@@ -126,6 +126,12 @@ export function getUpdatedIndexes(existing: IIndex, newRecords: DynamoDBRecord[]
   return updateCounts(existing, updates);
 }
 
+export function getModifiedIndexItems(existing: IIndexDictionary, updated: IIndexDictionary) {
+  return Object.keys(updated).filter((fieldKey: string) => {
+    return updated[fieldKey] !== existing[fieldKey];
+  });
+}
+
 export function getLogFields(records: DynamoDBRecord[], existingIndex?: IIndex, updatedIndexes?: IIndex) {
   const firstRecord = ddbAttVals.unwrap(records[0].dynamodb!.NewImage);
   return {
@@ -145,6 +151,10 @@ export function getLogFields(records: DynamoDBRecord[], existingIndex?: IIndex, 
     imageUserIdentityId: firstRecord.userIdentityId,
     imageUsername: firstRecord.username,
     imageWidth: firstRecord.meta && firstRecord.meta.width,
+    indexesModifiedPeopleCount: existingIndex && updatedIndexes &&
+      getModifiedIndexItems(existingIndex.people, updatedIndexes.people),
+    indexesModifiedTagCount: existingIndex && updatedIndexes &&
+      getModifiedIndexItems(existingIndex.tags, updatedIndexes.tags),
     indexesPeopleCount: existingIndex && Object.keys(existingIndex.people).length,
     indexesTagCount: existingIndex && Object.keys(existingIndex.tags).length,
     indexesUpdatedPeopleCount: updatedIndexes && Object.keys(updatedIndexes.people).length,

--- a/fotos/stream__test__.ts
+++ b/fotos/stream__test__.ts
@@ -1,5 +1,6 @@
 import { DynamoDBRecord } from "aws-lambda";
 import * as test from "tape";
+import { getZeroCount } from "./indexes";
 import * as stream from "./stream";
 import { IIndex } from "./types";
 
@@ -250,4 +251,193 @@ test("getUpdatedIndexes - modifies existing index with tags and people", (t) => 
     },
   });
   t.end();
+});
+
+test("get image records indexes", (t) => {
+  const recordsRaw: DynamoDBRecord[] = [
+    {
+      awsRegion: "us-east-1",
+      dynamodb: {
+        ApproximateCreationDateTime: 1566962110,
+        Keys: {
+          id: { S: "9b1d5700-c8c3-11e9-bf5e-ab9eba55ceea" },
+          username: { S: "tester" },
+        },
+        OldImage: {
+          birthtime: { N: "1563448223924" },
+          createdAt: { N: "1566907807784" },
+          group: { S: "sosnowski-roberts-alpha" },
+          id: { S: "9b1d5700-c8c3-11e9-bf5e-ab9eba55ceea" },
+          img_key: { S: "tester/steve.jpg" },
+          img_thumb_key: { S: "tester/steve-thumbnail.jpg" },
+          meta: { M: { height: { N: "1448" }, width: { N: "1488" } } },
+          people: { L: [{ S: "9ca94e30-c8c3-11e9-a794-7524c255cd6f" }] },
+          tags: {
+            L: [
+              { S: "Human" },
+              { S: "Person" },
+              { S: "Glasses" },
+              { S: "Accessories" },
+              { S: "Accessory" },
+              { S: "Apparel" },
+              { S: "Clothing" },
+              { S: "Coat" },
+              { S: "Suit" },
+              { S: "Overcoat" },
+            ],
+          },
+          traceMeta: {
+            M: {
+              parentId: { S: "03a4d4b0-c8c4-11e9-aa07-0d71283ce829" },
+              traceId: { S: "03a4d4b1-c8c4-11e9-aa07-0d71283ce829" },
+            },
+          },
+          updatedAt: { N: "1566907982467" },
+          userIdentityId: {
+            S: "us-east-1:e2824167-1682-4bdb-a285-f91e97e4cb03",
+          },
+          username: { S: "tester" },
+        },
+        SequenceNumber: "35734900000000002324267854",
+        SizeBytes: 1778,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+      eventID: "560a1933c812726f38fec9f05158b2b3",
+      eventName: "REMOVE",
+      eventSource: "aws:dynamodb",
+      eventSourceARN:
+        "arn:aws:dynamodb:us-east-1:366399188066:table/fotopia-web-app-alpha/stream/2019-08-20T12:25:36.318",
+      eventVersion: "1.1",
+    },
+  ];
+  const existingIndex: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
+    },
+    tags: {
+      Accessories : 1,
+      Accessory : 1,
+      Apparel : 1,
+      Clothing: 1,
+      Coat: 1,
+      Glasses: 1,
+      Human: 1,
+      Overcoat: 1,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+  const result = stream.getUpdatedIndexes(existingIndex, recordsRaw);
+
+  t.deepEqual(result, {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
+    },
+    tags: {
+      Accessories : 0,
+      Accessory : 0,
+      Apparel : 0,
+      Clothing: 0,
+      Coat: 0,
+      Glasses: 0,
+      Human: 0,
+      Overcoat: 0,
+      Person: 0,
+      Suit: 0,
+    },
+  });
+  t.end();
+});
+
+test("getZeroCount", (t) => {
+  const existing: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
+    },
+    tags: {
+      Accessories : 1,
+      Accessory : 1,
+      Apparel : 1,
+      Clothing: 1,
+      Coat: 1,
+      Glasses: 1,
+      Human: 1,
+      Overcoat: 1,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+  const updated: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
+    },
+    tags: {
+      Accessories : 0,
+      Accessory : 0,
+      Apparel : 0,
+      Clothing: 0,
+      Coat: 0,
+      Glasses: 0,
+      Human: 0,
+      Overcoat: 0,
+      Person: 0,
+      Suit: 0,
+    },
+  };
+
+  const resultExistingPeople = getZeroCount(existing.people);
+  const resultExistingTags = getZeroCount(existing.tags);
+  const resultUpdatedPeople = getZeroCount(updated.people);
+  const resultUpdatedTags = getZeroCount(updated.tags);
+
+  t.equal(resultExistingPeople, 0, `${resultExistingPeople} zero counts in existing people`);
+  t.equal(resultExistingTags, 0, `${resultExistingTags}  zero counts in existing tags`);
+  t.equal(resultUpdatedPeople, 1, `${resultUpdatedPeople}  zero counts in updated people`);
+  t.equal(resultUpdatedTags, 10, `${resultUpdatedTags}  zero counts in updated tags`);
+  t.end();
+});
+
+test("getModifiedIndexItems", (t) => {
+  const existing: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
+    },
+    tags: {
+      Accessories : 1,
+      Accessory : 1,
+      Apparel : 1,
+      Clothing: 1,
+      Coat: 1,
+      Glasses: 1,
+      Human: 1,
+      Overcoat: 1,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+  const updated: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
+    },
+    tags: {
+      Accessories : 0,
+      Accessory : 0,
+      Apparel : 0,
+      Clothing: 0,
+      Coat: 0,
+      Glasses: 0,
+      Human: 2,
+      Overcoat: 0,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+
+  const resultPeople = stream.getModifiedIndexItems(existing.people, updated.people);
+  const resultTags = stream.getModifiedIndexItems(existing.tags, updated.tags);
+
+  t.equal(resultPeople.length, 1, `${resultPeople.length} modified people`);
+  t.equal(resultTags.length, 8, `${resultTags.length} modified tags`);
+  t.end();
+
 });

--- a/fotos/types/stream.ts
+++ b/fotos/types/stream.ts
@@ -1,3 +1,5 @@
+import { ITraceMeta } from "./common";
+
 export interface IIndex {
   people: IIndexDictionary;
   tags: IIndexDictionary;
@@ -17,4 +19,9 @@ export interface IIndexFields {
     new: number[];
     old: number[];
   };
+}
+
+export interface IPutIndexRequest {
+  index: IIndex;
+  traceMeta: ITraceMeta;
 }

--- a/fotos/types/update.ts
+++ b/fotos/types/update.ts
@@ -4,5 +4,7 @@ import { IImageMeta } from "./images";
 export interface IUpdateBody {
   faceMatches?: IFaceWithPeople[];
   people?: string[];
-  meta?: IImageMeta;
+  meta?: {
+    [name: string]: string | number | undefined;
+  };
 }

--- a/fotos/types/update.ts
+++ b/fotos/types/update.ts
@@ -1,6 +1,8 @@
 import { IFaceWithPeople } from "./faces";
+import { IImageMeta } from "./images";
 
 export interface IUpdateBody {
   faceMatches?: IFaceWithPeople[];
-  people: string[];
+  people?: string[];
+  meta?: IImageMeta;
 }

--- a/fotos/types/update.ts
+++ b/fotos/types/update.ts
@@ -1,5 +1,5 @@
+import { ITraceMeta } from "./common";
 import { IFaceWithPeople } from "./faces";
-import { IImageMeta } from "./images";
 
 export interface IUpdateBody {
   faceMatches?: IFaceWithPeople[];
@@ -7,4 +7,5 @@ export interface IUpdateBody {
   meta?: {
     [name: string]: string | number | undefined;
   };
+  traceMeta?: ITraceMeta;
 }

--- a/fotos/update.ts
+++ b/fotos/update.ts
@@ -77,8 +77,8 @@ export async function updateItem(event: APIGatewayProxyEvent, context: Context, 
   const data = event.body ? JSON.parse(event.body) : null;
   const traceMeta: ITraceMeta | undefined = data!.traceMeta;
   const requestBody: IUpdateBody = {
-    faceMatches: data.faceMatches,
-    people: data.people,
+    faceMatches: data.faceMatches || [],
+    people: data.people || [],
   };
 
   const loggerBaseParams: ILoggerBaseParams = {

--- a/fotos/update.ts
+++ b/fotos/update.ts
@@ -76,7 +76,10 @@ export async function updateItem(event: APIGatewayProxyEvent, context: Context, 
   const startTime: number = Date.now();
   const data = event.body ? JSON.parse(event.body) : null;
   const traceMeta: ITraceMeta | undefined = data!.traceMeta;
-  const requestBody: IUpdateBody = data;
+  const requestBody: IUpdateBody = {
+    faceMatches: data.faceMatches,
+    people: data.people,
+  };
 
   const loggerBaseParams: ILoggerBaseParams = {
     id: uuid.v1(),

--- a/fotos/update.ts
+++ b/fotos/update.ts
@@ -78,6 +78,7 @@ export async function updateItem(event: APIGatewayProxyEvent, context: Context, 
   const traceMeta: ITraceMeta | undefined = data!.traceMeta;
   const requestBody: IUpdateBody = {
     faceMatches: data.faceMatches || [],
+    meta: data.meta || {},
     people: data.people || [],
   };
 

--- a/fotos/update__test__.ts
+++ b/fotos/update__test__.ts
@@ -25,3 +25,22 @@ test("getDynamoDbParams", (t) => {
     t.fail(e);
   }
 });
+
+test("getDynamoDbParams - w undefined keys", (t) => {
+  const reqBodyWithUndefined = {
+    meta: {
+      someKey: "blah",
+    },
+    people: undefined,
+    tags: undefined,
+  };
+  process.env.DYNAMODB_TABLE = "TABLE";
+  try {
+    const params = update.getDynamoDbParams(requestParams, reqBodyWithUndefined);
+    t.deepEqual(params.Key.username, requestParams.username);
+    t.equal(params.UpdateExpression, "SET #meta = :meta, updatedAt = :updatedAt");
+    t.end();
+  } catch (e) {
+    t.fail(e);
+  }
+});

--- a/fotos/update__test__.ts
+++ b/fotos/update__test__.ts
@@ -1,15 +1,13 @@
 import * as test from "tape";
 import * as uuid from "uuid";
+import { IUpdateBody } from "./types";
 import * as update from "./update";
 
 const requestParams = {
   id: uuid.v1(),
   username: "pedro",
 };
-const requestBody = {
-  meta: {
-    location: "Peru",
-  },
+const requestBody: IUpdateBody = {
   people: ["Bob"],
 };
 
@@ -18,7 +16,7 @@ test("getDynamoDbParams", (t) => {
   try {
     const params = update.getDynamoDbParams(requestParams, requestBody);
     t.deepEqual(params.Key.username, requestParams.username);
-    t.equal(params.UpdateExpression, "SET #meta = :meta, #people = :people, updatedAt = :updatedAt");
+    t.equal(params.UpdateExpression, "SET #people = :people, updatedAt = :updatedAt");
     t.end();
   } catch (e) {
     t.fail(e);

--- a/fotos/update__test__.ts
+++ b/fotos/update__test__.ts
@@ -8,6 +8,9 @@ const requestParams = {
   username: "pedro",
 };
 const requestBody: IUpdateBody = {
+  meta: {
+    location: "Peru",
+  },
   people: ["Bob"],
 };
 
@@ -16,7 +19,7 @@ test("getDynamoDbParams", (t) => {
   try {
     const params = update.getDynamoDbParams(requestParams, requestBody);
     t.deepEqual(params.Key.username, requestParams.username);
-    t.equal(params.UpdateExpression, "SET #people = :people, updatedAt = :updatedAt");
+    t.equal(params.UpdateExpression, "SET #meta = :meta, #people = :people, updatedAt = :updatedAt");
     t.end();
   } catch (e) {
     t.fail(e);

--- a/logging/serverless.yml
+++ b/logging/serverless.yml
@@ -29,6 +29,7 @@ provider:
     LogGroupName14: ${file(./serverlessEnv.js):config.LOG_GROUP_PREFIX}${opt:stage, self:provider.stage}-collectionCreate
     LogGroupName15: ${file(./serverlessEnv.js):config.LOG_GROUP_PREFIX}${opt:stage, self:provider.stage}-collectionDelete
     LogGroupName16: ${file(./serverlessEnv.js):config.LOG_GROUP_PREFIX}${opt:stage, self:provider.stage}-peopleUpdate
+    LogGroupName17: ${file(./serverlessEnv.js):config.LOG_GROUP_PREFIX}${opt:stage, self:provider.stage}-indexesUpdate
     FilterPattern: ''
 resources:
   Resources:
@@ -235,6 +236,16 @@ resources:
             - CloudwatchLambdaHandler
             - Arn
         LogGroupName: ${self:provider.environment.LogGroupName16}
+        FilterPattern: ${self:provider.environment.FilterPattern}
+      DependsOn: ExecutePermission
+    CloudwatchSubscriptionFilter17:
+      Type: "AWS::Logs::SubscriptionFilter"
+      Properties:
+        DestinationArn:
+          "Fn::GetAtt":
+            - CloudwatchLambdaHandler
+            - Arn
+        LogGroupName: ${self:provider.environment.LogGroupName17}
         FilterPattern: ${self:provider.environment.FilterPattern}
       DependsOn: ExecutePermission
     LambdaIAMRole:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "functional-prod": "STAGE=prod tape -r ts-node/register -r babel-register ./test/functional.remote.ts | tap-spec",
     "functional-dev": "STAGE=dev tape -r ts-node/register -r babel-register ./test/functional.remote.ts | tap-spec",
     "functional-alpha": "STAGE=alpha tape -r ts-node/register -r babel-register ./test/functional.remote.ts | tap-spec",
-    "lint": "tslint -c tslint.json 'fotos/**/*.ts'"
+    "lint": "tslint -c tslint.json 'fotos/**/*.ts' 'test/**/*.ts'"
   },
   "pre-commit": [
     "lint",

--- a/serverless.yml
+++ b/serverless.yml
@@ -180,6 +180,7 @@ functions:
           method: post
           cors: true
           authorizer: aws_iam
+
   indexes:
     handler: fotos/indexes.getItem
     memorySize: 128
@@ -189,6 +190,17 @@ functions:
           method: get
           cors: true
           authorizer: aws_iam
+
+  indexesUpdate:
+    handler: fotos/indexes.putItem
+    memorySize: 128
+    events:
+      - http:
+          path: indexes/update
+          method: put
+          cors: true
+          authorizer: aws_iam
+
   people:
     handler: fotos/people.getItem
     memorySize: 128

--- a/serverless.yml
+++ b/serverless.yml
@@ -104,6 +104,7 @@ provider:
         - "rekognition:DeleteCollection"
         - "rekognition:DeleteFaces"
         - "rekognition:DetectLabels"
+        - "rekognition:ListFaces"
         - "rekognition:SearchFaces"
       Resource: "*"
 functions:

--- a/test/functional.ts
+++ b/test/functional.ts
@@ -16,6 +16,9 @@ config();
 export default function(auth: any, api: any, upload: any) {
   setup(auth)
     .then((setupData: any) => {
+      // to check - there may be a prob when I delete the
+      // index and people objects, this adds time and so
+      // tests that check for people dont pass...?
       deleteAllTestData(setupData, api);
       uploadTests(setupData, upload);
       createTests(setupData, api);

--- a/test/functional.ts
+++ b/test/functional.ts
@@ -5,6 +5,7 @@ import createTests from "./functional/create";
 import deleteTests from "./functional/del";
 import deleteAllTestData from "./functional/deleteMocks";
 import getTests from "./functional/get";
+import indexesTests from "./functional/indexes";
 import peopleTests from "./functional/people";
 import queryTests from "./functional/query";
 import setup from "./functional/setup";
@@ -23,6 +24,7 @@ export default function(auth: any, api: any, upload: any) {
       uploadTests(setupData, upload);
       createTests(setupData, api);
       queryTests(setupData, api);
+      indexesTests(setupData, api);
       getTests(setupData, api);
       updateTests(setupData, api);
       peopleTests(setupData, api);

--- a/test/functional/createIndexAdjustment.ts
+++ b/test/functional/createIndexAdjustment.ts
@@ -1,10 +1,22 @@
-export function createIndexAdjustment(arr) {
+export function createIndexSubtract(arr) {
   const obj: any = {};
   arr.forEach((item) => {
-    if (obj[item]) { // this might fail if the item key is falsy??
+    if (obj[item]) { // this might fail if the item key is falsy?? .i.e value of 0
       obj[item]--;
     } else {
       obj[item] = -1;
+    }
+  });
+  return obj;
+}
+
+export function createIndexAdd(arr) {
+  const obj: any = {};
+  arr.forEach((item) => {
+    if (obj[item]) {
+      obj[item]++;
+    } else {
+      obj[item] = 1;
     }
   });
   return obj;

--- a/test/functional/createIndexChangeTable.ts
+++ b/test/functional/createIndexChangeTable.ts
@@ -1,0 +1,39 @@
+import { IImage, IIndex } from "../../fotos/types";
+
+export const MODES = {
+  ADD: "ADD",
+  REMOVE:  "REMOVE",
+};
+export function createIndexChangeTable(mode: string, images: IImage[], existingIndex: IIndex, actualIndex: IIndex) {
+  const people = Object.keys(actualIndex.people).map((p: string) => {
+    const imagesWithPerson = images.filter((img) => img.people && img.people.includes(p));
+    const existing: number = isNaN(existingIndex.people[p]) ? 0 : existingIndex.people[p];
+    return {
+      actual: actualIndex.people[p],
+      existing,
+      expected: mode === MODES.ADD ? existing + imagesWithPerson.length : existing - imagesWithPerson.length,
+      id: p,
+      images: imagesWithPerson.map((img) => img.img_key),
+    };
+  });
+  const tags = Object.keys(actualIndex.tags).map((t: string) => {
+    const imagesWithTag = images.filter((img) => img.tags && img.tags.includes(t));
+    const existing: number = isNaN(existingIndex.tags[t]) ? 0 : existingIndex.tags[t];
+    return {
+      actual: actualIndex.tags[t],
+      existing,
+      expected: mode === MODES.ADD ? existing + imagesWithTag.length : existing - imagesWithTag.length ,
+      id: t,
+      images: imagesWithTag.map((img) => img.img_key),
+    };
+  });
+  const valid = {
+    people: people.filter((p) => p.actual !== p.expected),
+    tags: tags.filter((t) => t.actual !== t.expected),
+  };
+  return {
+    people,
+    tags,
+    valid,
+  };
+}

--- a/test/functional/del.ts
+++ b/test/functional/del.ts
@@ -1,9 +1,10 @@
 import * as test from "tape";
 import { IImage, IIndex, IPerson, IQueryBody } from "../../fotos/types";
-import { createIndexAdjustment } from "./createIndexAdjustment";
+import { createIndexSubtract } from "./createIndexAdjustment";
 import formatError from "./formatError";
 import getEndpointPath from "./getEndpointPath";
 import { getIncorrectIndexUpdates } from "./getIncorrectIndexUpdates";
+import { getItemsInImages } from "./getItemsInImages";
 
 export default function deleteTests(setupData, api) {
 
@@ -167,18 +168,14 @@ export default function deleteTests(setupData, api) {
     retry();
   });
 
-  test("createIndexAdjustment should show correct minus vales", (t) => {
+  test("createIndexSubtract should show correct minus vales", (t) => {
     const testArr = ["bob", "amelia", "amelia"];
-    const result = createIndexAdjustment(testArr);
+    const result = createIndexSubtract(testArr);
 
     t.equal(result.bob, -1, "minus 1 for bob");
     t.equal(result.amelia, -2, "minus 2 for amelia");
     t.end();
   });
-
-  const getItemsInImages = (key: string, imgArr: IImage[]): string[] => {
-    return imgArr.reduce((accum, img) => accum.concat(img[key]), [] as string[]);
-  };
 
   test("getItemsInImages should collate key and not dedupe", (t) => {
     const testImageArr: IImage[] = [{
@@ -223,8 +220,8 @@ export default function deleteTests(setupData, api) {
     const testImagesPeople = getItemsInImages("people", allImages);
     const testImagesTags = getItemsInImages("tags", allImages);
     const indexAdjustments = {
-      people: createIndexAdjustment(testImagesPeople),
-      tags: createIndexAdjustment(testImagesTags),
+      people: createIndexSubtract(testImagesPeople),
+      tags: createIndexSubtract(testImagesTags),
     };
 
     let retryCount = 0;

--- a/test/functional/del.ts
+++ b/test/functional/del.ts
@@ -213,17 +213,7 @@ export default function deleteTests(setupData, api) {
             incorrectUpdates.tags.length
           } incorrectly adjusted tags and ${
             incorrectUpdates.people.length
-          } incorrectly adjusted people after ${retryCount} retries. ${JSON.stringify({
-            existingIndexes,
-            indexAdjustments,
-            responseBody,
-          })}.  Images tags/people: ${
-            JSON.stringify(allImages.map((i) => ({
-              img_key: i.img_key,
-              people: i.people,
-              tags: i.tags,
-            })))
-          }`);
+          } incorrectly adjusted people after ${retryCount} retries.`);
           t.end();
         }
       } else {

--- a/test/functional/del.ts
+++ b/test/functional/del.ts
@@ -3,6 +3,7 @@ import { IImage, IIndex, IPerson, IQueryBody } from "../../fotos/types";
 import { createIndexAdjustment } from "./createIndexAdjustment";
 import formatError from "./formatError";
 import getEndpointPath from "./getEndpointPath";
+import { getIncorrectIndexUpdates } from "./getIncorrectIndexUpdates";
 
 export default function deleteTests(setupData, api) {
 
@@ -183,15 +184,6 @@ export default function deleteTests(setupData, api) {
     t.end();
   });
 
-  const getIncorrectIndexUpdates = (indexAdjustments, sourceIndex: IIndex, updatedIndex: IIndex) => {
-    return {
-      people: Object.keys(indexAdjustments.people)
-        .filter((p) => updatedIndex.people[p] !==  sourceIndex.people[p] + indexAdjustments.people[p]),
-      tags: Object.keys(indexAdjustments.tags)
-        .filter((tag) => updatedIndex.tags[tag] !==  sourceIndex.tags[tag] + indexAdjustments.tags[tag]),
-    };
-  };
-
   test("get indexes should return an index object with 0 counts for ppl and tags matching test data", (t) => {
     const allImages: IImage[] = [imageOne].concat(imagesWithFourPeople);
     const testImagesPeople = getItemsInImages("people", allImages);
@@ -221,7 +213,17 @@ export default function deleteTests(setupData, api) {
             incorrectUpdates.tags.length
           } incorrectly adjusted tags and ${
             incorrectUpdates.people.length
-          } incorrectly adjusted people after ${retryCount} retries`);
+          } incorrectly adjusted people after ${retryCount} retries. ${JSON.stringify({
+            existingIndexes,
+            indexAdjustments,
+            responseBody,
+          })}.  Images tags/people: ${
+            JSON.stringify(allImages.map((i) => ({
+              img_key: i.img_key,
+              people: i.people,
+              tags: i.tags,
+            })))
+          }`);
           t.end();
         }
       } else {

--- a/test/functional/del.ts
+++ b/test/functional/del.ts
@@ -111,13 +111,6 @@ export default function deleteTests(setupData, api) {
       .catch(formatError);
   });
 
-  test("wait for 3 seconds", (t) => {
-    setTimeout(() => {
-      t.comment("Waited for 3 secs");
-      t.end();
-    }, 3000);
-  });
-
   test("get people should return no results with the test image ids", (t) => {
     const imageIds = [imageOne.id].concat(imagesWithFourPeople.map((i) => i.id));
     api

--- a/test/functional/deleteAll.ts
+++ b/test/functional/deleteAll.ts
@@ -1,4 +1,6 @@
+import * as AWS from "aws-sdk";
 import * as test from "tape";
+
 import { IImage, IIndex, IPerson, IQueryBody } from "../../fotos/types";
 import { createIndexAdjustment } from "./createIndexAdjustment";
 import formatError from "./formatError";
@@ -160,6 +162,78 @@ export default function deleteAllNotJustTestData(setupData, api) {
           0,
           `all people adjustments are correct. Checked ${Object.keys(indexAdjustments.people).length} adjustments`,
         );
+        t.end();
+      })
+      .catch(formatError);
+  });
+
+  test("Update people to be an empty array", (t) => {
+    const people: IPerson[] = [];
+    const body = {
+      people,
+    };
+    api
+      .put(setupData.apiUrl, "/people/update", {
+        body,
+      })
+      .then((responseBody) => {
+        t.ok(responseBody, "people updated to [] ok");
+        t.end();
+      })
+      .catch(formatError);
+  });
+
+  let rekognitionFaceIds;
+
+  AWS.config.update({region: "us-east-1"});
+  const rekognition = new AWS.Rekognition();
+
+  test("Get the rekognition faces", (t) => {
+    // tslint:disable-next-line:no-console
+    console.log("region", process.env.AWS_REGION);
+    const params = {
+      CollectionId: setupData.collectionId,
+    };
+    rekognition.listFaces(params).promise()
+      .then((faces) => {
+        t.ok(faces, `Faces retrieved from collection ${setupData.collectionId}`);
+        rekognitionFaceIds = faces!.Faces!.map((f) => f.FaceId);
+        t.ok(rekognitionFaceIds, `Faces mapped: ${rekognitionFaceIds.length}`);
+        t.end();
+      })
+      .catch(formatError);
+
+  });
+
+  test("Delete faces in the rekognition collection", (t) => {
+    const params = {
+      CollectionId: "myphotos",
+      FaceIds: rekognitionFaceIds,
+    };
+    rekognition.deleteFaces(params).promise()
+      .then((faces) => {
+        t.ok(faces, `Faces deleted from collection ${setupData.collectionId}`);
+        const deletedFaces = faces!.DeletedFaces!;
+        t.deepEqual(deletedFaces, rekognitionFaceIds, `Faces deleted are same as list retrieved`);
+        t.end();
+      })
+      .catch(formatError);
+  });
+
+  test("Update indexes to be an empty IIndex", (t) => {
+    const index: IIndex = {
+      people: {},
+      tags: {},
+    };
+    const body = {
+      index,
+    };
+    api
+      .put(setupData.apiUrl, "/indexes/update", {
+        body,
+      })
+      .then((responseBody) => {
+        t.ok(responseBody, "index updated to empty obj ok");
         t.end();
       })
       .catch(formatError);

--- a/test/functional/deleteAll.ts
+++ b/test/functional/deleteAll.ts
@@ -184,7 +184,7 @@ export default function deleteAllNotJustTestData(setupData, api) {
   });
 
   let rekognitionFaceIds;
-  AWS.config.update({region: ( process.env.AWS_REGION || "us-east-1") });
+  AWS.config.update({region: setupData.region });
   const rekognition = new AWS.Rekognition();
 
   test("Get the rekognition faces", (t) => {

--- a/test/functional/deleteAll.ts
+++ b/test/functional/deleteAll.ts
@@ -184,13 +184,10 @@ export default function deleteAllNotJustTestData(setupData, api) {
   });
 
   let rekognitionFaceIds;
-
-  AWS.config.update({region: "us-east-1"});
+  AWS.config.update({region: ( process.env.AWS_REGION || "us-east-1") });
   const rekognition = new AWS.Rekognition();
 
   test("Get the rekognition faces", (t) => {
-    // tslint:disable-next-line:no-console
-    console.log("region", process.env.AWS_REGION);
     const params = {
       CollectionId: setupData.collectionId,
     };

--- a/test/functional/deleteAll.ts
+++ b/test/functional/deleteAll.ts
@@ -1,4 +1,3 @@
-import * as AWS from "aws-sdk";
 import * as test from "tape";
 
 import { IImage, IIndex, IPerson, IQueryBody } from "../../fotos/types";
@@ -178,40 +177,6 @@ export default function deleteAllNotJustTestData(setupData, api) {
       })
       .then((responseBody) => {
         t.ok(responseBody, "people updated to [] ok");
-        t.end();
-      })
-      .catch(formatError);
-  });
-
-  let rekognitionFaceIds;
-  AWS.config.update({region: setupData.region });
-  const rekognition = new AWS.Rekognition();
-
-  test("Get the rekognition faces", (t) => {
-    const params = {
-      CollectionId: setupData.collectionId,
-    };
-    rekognition.listFaces(params).promise()
-      .then((faces) => {
-        t.ok(faces, `Faces retrieved from collection ${setupData.collectionId}`);
-        rekognitionFaceIds = faces!.Faces!.map((f) => f.FaceId);
-        t.ok(rekognitionFaceIds, `Faces mapped: ${rekognitionFaceIds.length}`);
-        t.end();
-      })
-      .catch(formatError);
-
-  });
-
-  test("Delete faces in the rekognition collection", (t) => {
-    const params = {
-      CollectionId: "myphotos",
-      FaceIds: rekognitionFaceIds,
-    };
-    rekognition.deleteFaces(params).promise()
-      .then((faces) => {
-        t.ok(faces, `Faces deleted from collection ${setupData.collectionId}`);
-        const deletedFaces = faces!.DeletedFaces!;
-        t.deepEqual(deletedFaces, rekognitionFaceIds, `Faces deleted are same as list retrieved`);
         t.end();
       })
       .catch(formatError);

--- a/test/functional/deleteMocks.ts
+++ b/test/functional/deleteMocks.ts
@@ -1,6 +1,6 @@
 import * as test from "tape";
 import { IImage, IIndex, IPerson, IQueryBody } from "../../fotos/types";
-import { createIndexAdjustment } from "./createIndexAdjustment";
+import { createIndexSubtract } from "./createIndexAdjustment";
 import formatError from "./formatError";
 import getEndpointPath from "./getEndpointPath";
 import { getIncorrectIndexUpdates } from "./getIncorrectIndexUpdates";
@@ -167,8 +167,8 @@ export default function deleteAllTestData(setupData, api) {
     const testImagesTags = deleteImages.reduce((accum, img) => accum.concat(img.tags!), [] as string[]);
 
     const indexAdjustments = {
-      people: createIndexAdjustment(testImagesPeople),
-      tags: createIndexAdjustment(testImagesTags),
+      people: createIndexSubtract(testImagesPeople),
+      tags: createIndexSubtract(testImagesTags),
     };
 
     let retryCount = 0;

--- a/test/functional/getIncorrectIndexUpdates.ts
+++ b/test/functional/getIncorrectIndexUpdates.ts
@@ -1,0 +1,12 @@
+import { IIndex } from "../../fotos/types";
+
+export function getIncorrectIndexUpdates(indexAdjustments, sourceIndex: IIndex, updatedIndex: IIndex) {
+  return {
+    people: Object.keys(indexAdjustments.people)
+      .filter((p) => updatedIndex.people[p] !== 0 ||
+        updatedIndex.people[p] !== sourceIndex.people[p] + indexAdjustments.people[p]),
+    tags: Object.keys(indexAdjustments.tags)
+      .filter((tag) => updatedIndex.tags[tag] !== 0 ||
+        updatedIndex.tags[tag] !== sourceIndex.tags[tag] + indexAdjustments.tags[tag]),
+  };
+}

--- a/test/functional/getItemsInImages.ts
+++ b/test/functional/getItemsInImages.ts
@@ -1,0 +1,5 @@
+import { IImage } from "../../fotos/types";
+
+export function getItemsInImages(key: string, imgArr: IImage[]): string[] {
+  return imgArr.reduce((accum, img) => accum.concat(img[key]), [] as string[]);
+}

--- a/test/functional/indexes.ts
+++ b/test/functional/indexes.ts
@@ -2,10 +2,8 @@ import * as test from "tape";
 import {
   IImage, IIndex, IQueryBody,
 } from "../../fotos/types";
-import { createIndexAdd } from "./createIndexAdjustment";
+import { createIndexChangeTable, MODES } from "./createIndexChangeTable";
 import formatError from "./formatError";
-import { getIncorrectIndexUpdates } from "./getIncorrectIndexUpdates";
-import { getItemsInImages } from "./getItemsInImages";
 
 export default function indexesTests(setupData, api) {
 
@@ -35,43 +33,8 @@ export default function indexesTests(setupData, api) {
       .catch(formatError);
   });
 
-  function createIndexChangeTable(images: IImage[], existingIndex: IIndex, actualIndex: IIndex) {
-    const people = Object.keys(actualIndex.people).map((p: string) => {
-      const imagesWithPerson = images.filter((img) => img.people && img.people.includes(p));
-      const existing: number = isNaN(existingIndex.people[p]) ? 0 : existingIndex.people[p];
-      return {
-        actual: actualIndex.people[p],
-        existing,
-        expected: existing + imagesWithPerson.length,
-        id: p,
-        images: imagesWithPerson.map((img) => img.img_key),
-      };
-    });
-    const tags = Object.keys(actualIndex.tags).map((t: string) => {
-      const imagesWithTag = images.filter((img) => img.tags && img.tags.includes(t));
-      const existing: number = isNaN(existingIndex.tags[t]) ? 0 : existingIndex.tags[t];
-      return {
-        actual: actualIndex.tags[t],
-        existing,
-        expected: existing + imagesWithTag.length,
-        id: t,
-        images: imagesWithTag.map((img) => img.img_key),
-      };
-    });
-
-    const valid = {
-      people: people.filter((p) => p.actual !== p.expected),
-      tags: tags.filter((t) => t.actual !== t.expected),
-    };
-    return {
-      people,
-      tags,
-      valid,
-    };
-  }
-
   test("get indexes, should have at least tags and people of test images", (t) => {
-
+    // need to replace this with baseline index that we grab before tests start
     const existingIndexes = {
       people: {},
       tags: {},
@@ -83,7 +46,7 @@ export default function indexesTests(setupData, api) {
       fn: api.get,
     };
     const retryableTestThen = (responseBody: IIndex) => {
-      const changes = createIndexChangeTable(testImages, existingIndexes, responseBody);
+      const changes = createIndexChangeTable(MODES.ADD, testImages, existingIndexes, responseBody);
       if (changes.valid.people.length + changes.valid.tags.length > 0) {
         if (retryCount < retryStrategy.length) {
           setTimeout(() => {

--- a/test/functional/indexes.ts
+++ b/test/functional/indexes.ts
@@ -15,7 +15,7 @@ export default function indexesTests(setupData, api) {
       fn: api.get,
     };
     const retryableTestThen = (responseBody: IIndex) => {
-      if (Object.keys(responseBody.tags).length < 10 && Object.keys(responseBody.people).length < 5) {
+      if (Object.keys(responseBody.tags).length < 10 || Object.keys(responseBody.people).length < 5) {
         if (retryCount < retryStrategy.length) {
           setTimeout(() => {
             retryCount++;
@@ -36,7 +36,6 @@ export default function indexesTests(setupData, api) {
           true,
           `tags length of ${Object.keys(responseBody.tags).length} - tags from two images`,
         );
-
         t.equal(
           Object.keys(responseBody.people).length  >= 5,
           true,

--- a/test/functional/indexes.ts
+++ b/test/functional/indexes.ts
@@ -1,0 +1,59 @@
+import * as test from "tape";
+import {
+  IIndex,
+} from "../../fotos/types";
+import formatError from "./formatError";
+
+export default function indexesTests(setupData, api) {
+
+  const retryStrategy = [500, 1000, 2000, 5000];
+
+  test("get indexes, should have at least 5 people and 10 tags", (t) => {
+    let retryCount = 0;
+    const retryableTest = {
+      args: [setupData.apiUrl, "/indexes"],
+      fn: api.get,
+    };
+    const retryableTestThen = (responseBody: IIndex) => {
+      if (Object.keys(responseBody.tags).length < 10 && Object.keys(responseBody.people).length < 5) {
+        if (retryCount < retryStrategy.length) {
+          setTimeout(() => {
+            retryCount++;
+            t.comment(`Retry # ${retryCount} after ${retryStrategy[retryCount - 1]}ms`);
+            retry();
+          }, retryStrategy[retryCount]);
+        } else {
+          t.fail(`Failed - index has ${
+            Object.keys(responseBody.tags).length
+          } tags and ${
+            Object.keys(responseBody.people).length
+          } people after ${retryCount} retries`);
+          t.end();
+        }
+      } else {
+        t.equal(
+          Object.keys(responseBody.tags).length  >= 10,
+          true,
+          `tags length of ${Object.keys(responseBody.tags).length} - tags from two images`,
+        );
+
+        t.equal(
+          Object.keys(responseBody.people).length  >= 5,
+          true,
+          `people length of ${
+            Object.keys(responseBody.people).length
+          } - at least each person from image one and image with 4 people`,
+        );
+        t.end();
+      }
+    };
+    const retry = () => {
+      retryableTest.fn.apply(this, retryableTest.args)
+        .then(retryableTestThen)
+        .catch(formatError);
+    };
+
+    retry();
+  });
+
+}

--- a/test/functional/people.ts
+++ b/test/functional/people.ts
@@ -54,7 +54,6 @@ export default function peopleTests(setupData, api) {
   });
 
   test("query all to get the test image records", (t) => {
-
     const query: IQueryBody = {
       criteria: {
         people: [],
@@ -71,28 +70,94 @@ export default function peopleTests(setupData, api) {
       .then((responseBody: IImage[]) => {
         imageWithOnePerson = responseBody.find((rec) => rec.img_key === setupData.records[0].img_key);
         t.ok(imageWithOnePerson, "image one found");
+        imageWithFourPeople = responseBody.find((rec) => rec.img_key === setupData.records[1].img_key);
+        t.ok(imageWithFourPeople, "image with four people found");
+        t.end();
+      })
+      .catch(formatError);
+  });
+
+  // do a seperate retry get with both images to check they have the
+  // people - img w 4 has been observed as failing due to a def race condition
+  test("image w 1 person has person populated", (t) => {
+    const apiPath = getEndpointPath(imageWithOnePerson);
+    let retryCount = 0;
+    const retryableTest = {
+      args: [setupData.apiUrl, apiPath],
+      fn: api.get,
+    };
+    const retryableTestThen = (responseBody: IImage) => {
+      if (responseBody!.people!.length !== 1) {
+        if (retryCount < retryStrategy.length) {
+          setTimeout(() => {
+            retryCount++;
+            t.comment(`Retry # ${retryCount} after ${retryStrategy[retryCount - 1]}ms`);
+            retry();
+          }, retryStrategy[retryCount]);
+        } else {
+          t.fail(`Failed - image has ${responseBody!.people!.length} people after ${retryCount} retries`);
+          t.end();
+        }
+      } else {
+        imageWithOnePerson = responseBody;
         t.equal(
           imageWithOnePerson!.people!.length,
           1,
           `image has people length of ${imageWithOnePerson!.people!.length}`,
         );
-        imageWithFourPeople = responseBody.find((rec) => rec.img_key === setupData.records[1].img_key);
-        t.ok(imageWithFourPeople, "image with four people found");
+        t.end();
+      }
+    };
+    const retry = () => {
+      retryableTest.fn.apply(this, retryableTest.args)
+        .then(retryableTestThen)
+        .catch(formatError);
+    };
+
+    retry();
+  });
+
+  test("image w 4 people has people populated", (t) => {
+    const apiPath = getEndpointPath(imageWithFourPeople);
+    let retryCount = 0;
+    const retryableTest = {
+      args: [setupData.apiUrl, apiPath],
+      fn: api.get,
+    };
+    const retryableTestThen = (responseBody: IImage) => {
+      if (responseBody!.people!.length !== 4) {
+        if (retryCount < retryStrategy.length) {
+          setTimeout(() => {
+            retryCount++;
+            t.comment(`Retry # ${retryCount} after ${retryStrategy[retryCount - 1]}ms`);
+            retry();
+          }, retryStrategy[retryCount]);
+        } else {
+          t.fail(`Failed - image has ${responseBody!.people!.length} people after ${retryCount} retries`);
+          t.end();
+        }
+      } else {
+        imageWithFourPeople = responseBody;
         t.equal(
           imageWithFourPeople!.people!.length,
           4,
           `image w 4 has people length of ${imageWithFourPeople!.people!.length}`,
         );
         t.end();
-      })
-      .catch(formatError);
+      }
+    };
+    const retry = () => {
+      retryableTest.fn.apply(this, retryableTest.args)
+        .then(retryableTestThen)
+        .catch(formatError);
+    };
+
+    retry();
   });
 
   const updatedPerson: IPersonUpdateBody = {
     name: "Jacinta Dias",
   };
-
-  // purposely checking this later (see last test) to allow for latency
   test("updatePerson in image 1", (t) => {
     api
       .put(setupData.apiUrl, `/person/${imageWithOnePerson!.people![0]}`, {
@@ -100,6 +165,25 @@ export default function peopleTests(setupData, api) {
       })
       .then((responseBody) => {
         t.ok(responseBody, `update person in image one ${imageWithOnePerson!.people![0]} ok`);
+        t.end();
+      })
+      .catch(formatError);
+  });
+
+  test("getPeople - check updated name", (t) => {
+    api
+      .get(setupData.apiUrl, "/people")
+      .then((responseBody) => {
+        people = responseBody;
+        const personInResponse = responseBody.find(
+          (person) => person.id === imageWithOnePerson!.people![0],
+        );
+        t.ok(personInResponse, `image one found in people ${imageWithOnePerson!.people![0]} ok`);
+        t.equal(
+          personInResponse.name,
+          updatedPerson.name,
+          `updated name for person 1 ${imageWithOnePerson!.people![0]} in people`,
+        );
         t.end();
       })
       .catch(formatError);
@@ -119,9 +203,25 @@ export default function peopleTests(setupData, api) {
   });
 
   test("getPeople - check peopleMerge has removed person 1", (t) => {
-    api
-      .get(setupData.apiUrl, "/people")
-      .then((responseBody: IPerson[]) => {
+
+    let retryCount = 0;
+    const retryableTest = {
+      args: [setupData.apiUrl, "/people"],
+      fn: api.get,
+    };
+    const retryableTestThen = (responseBody: IPerson[]) => {
+      if (responseBody.length !== people.length - 1) {
+        if (retryCount < retryStrategy.length) {
+          setTimeout(() => {
+            retryCount++;
+            t.comment(`Retry # ${retryCount} after ${retryStrategy[retryCount - 1]}ms`);
+            retry();
+          }, retryStrategy[retryCount]);
+        } else {
+          t.fail(`Failed - ${responseBody.length} people after ${retryCount} retries`);
+          t.end();
+        }
+      } else {
         t.equal(responseBody.length, people.length - 1, "one less person");
         t.ok(responseBody.find(
           (person) => person.id === imageWithFourPeople!.people![0],
@@ -130,22 +230,38 @@ export default function peopleTests(setupData, api) {
           (person) => person.id === imageWithFourPeople!.people![1],
         ), "person 1 is not in the people object");
         t.end();
-      })
-      .catch(formatError);
-  });
+      }
+    };
+    const retry = () => {
+      retryableTest.fn.apply(this, retryableTest.args)
+        .then(retryableTestThen)
+        .catch(formatError);
+    };
 
-  test("wait for 3 seconds", (t) => {
-    setTimeout(() => {
-      t.comment("Waited for 3 secs");
-      t.end();
-    }, 3000);
+    retry();
+
   });
 
   test("after merge image that had person 1 now has person 0", (t) => {
     const apiPath = getEndpointPath(imageWithFourPeople);
-    api
-      .get(setupData.apiUrl, apiPath)
-      .then((responseBody: IImage) => {
+    let retryCount = 0;
+    const retryableTest = {
+      args: [setupData.apiUrl, apiPath],
+      fn: api.get,
+    };
+    const retryableTestThen = (responseBody: IImage) => {
+      if (responseBody!.people!.length !== 3) {
+        if (retryCount < retryStrategy.length) {
+          setTimeout(() => {
+            retryCount++;
+            t.comment(`Retry # ${retryCount} after ${retryStrategy[retryCount - 1]}ms`);
+            retry();
+          }, retryStrategy[retryCount]);
+        } else {
+          t.fail(`Failed - image has ${responseBody!.people!.length} people after ${retryCount} retries`);
+          t.end();
+        }
+      } else {
         t.equal(
           responseBody.img_key,
           imageWithFourPeople!.img_key,
@@ -168,27 +284,15 @@ export default function peopleTests(setupData, api) {
           "image has person 0",
         );
         t.end();
-      })
-      .catch(formatError);
-    });
-
-  // purposely doing this after name update to allow for latency
-  test("getPeople - check updated name", (t) => {
-    api
-      .get(setupData.apiUrl, "/people")
-      .then((responseBody) => {
-        people = responseBody;
-        const personInResponse = responseBody.find(
-          (person) => person.id === imageWithOnePerson!.people![0],
-        );
-        t.ok(personInResponse, `image one found in people ${imageWithOnePerson!.people![0]} ok`);
-        t.equal(
-          personInResponse.name,
-          updatedPerson.name,
-          `updated name for person 1 ${imageWithOnePerson!.people![0]} in people`,
-        );
         t.end();
-      })
-      .catch(formatError);
+      }
+    };
+    const retry = () => {
+      retryableTest.fn.apply(this, retryableTest.args)
+        .then(retryableTestThen)
+        .catch(formatError);
+    };
+
+    retry();
   });
 }

--- a/test/functional/people.ts
+++ b/test/functional/people.ts
@@ -284,7 +284,6 @@ export default function peopleTests(setupData, api) {
           "image has person 0",
         );
         t.end();
-        t.end();
       }
     };
     const retry = () => {

--- a/test/functional/people.ts
+++ b/test/functional/people.ts
@@ -23,7 +23,7 @@ export default function peopleTests(setupData, api) {
       fn: api.get,
     };
     const retryableTestThen = (responseBody: IPerson[]) => {
-      if (responseBody.length <= 5) {
+      if (responseBody.length < 5) {
         if (retryCount < retryStrategy.length) {
           setTimeout(() => {
             retryCount++;
@@ -31,7 +31,7 @@ export default function peopleTests(setupData, api) {
             retry();
           }, retryStrategy[retryCount]);
         } else {
-          t.fail(`Failed to get more than 5 people after ${retryCount} retries`);
+          t.fail(`Failed - retrieved only ${responseBody.length} people after ${retryCount} retries`);
           t.end();
         }
       } else {

--- a/test/functional/query.ts
+++ b/test/functional/query.ts
@@ -52,11 +52,4 @@ export default function queryTests(setupData, api) {
       .catch(formatError);
   });
 
-  // Query by person tests removed as they require that new people are
-  // created with the creation of the mock images. This involves an additon to the delete
-  // lambda, removing faces from rekognition collection and from people records.
-  // Cascading effects include:
-  // - person removal if no faces left in that person
-  // - removal of person in other images
-  // - removal of face similarity in images face data...
 }

--- a/test/functional/setup.ts
+++ b/test/functional/setup.ts
@@ -17,6 +17,7 @@ export default function setupTests(auth: any) {
   return getConfig()
     .then((config: any) => {
       setupData.apiUrl = config.ServiceEndpoint;
+      setupData.region = config.Region;
       return auth(config);
     })
     .then((signedIn) => {

--- a/test/functional/setup.ts
+++ b/test/functional/setup.ts
@@ -7,6 +7,7 @@ import { ISetupData } from "../types";
 export default function setupTests(auth: any) {
   const setupData: ISetupData = {
     apiUrl: "",
+    collectionId: `${process.env.FOTOPIA_GROUP}-${process.env.STAGE}`,
     images: [],
     records: [],
     startTime: Date.now(),

--- a/test/functional/update.ts
+++ b/test/functional/update.ts
@@ -53,7 +53,17 @@ export default function updateTests(setupData: ISetupData, api) {
       .then((responseBody: IImage) => {
         t.equal(responseBody.id, imageWithFourPeople!.id);
         t.equal(responseBody.meta.newProperty, "squirrel", "updated data");
-        t.ok(responseBody.tags!.includes(imageWithFourPeople!.tags![0]), "existing data unaffected");
+        t.equal(
+          responseBody.meta.height,
+          imageWithFourPeople!.meta.height,
+          `existing meta heigh ${responseBody.meta.height} unaffected`,
+        );
+        t.equal(
+          responseBody.meta.width,
+          imageWithFourPeople!.meta.width,
+          `existing meta width ${responseBody.meta.width} unaffected`,
+        );
+        t.ok(responseBody.tags!.includes(imageWithFourPeople!.tags![0]), "existing other props unaffected");
       })
       .catch(formatError);
   });

--- a/test/functional/update.ts
+++ b/test/functional/update.ts
@@ -32,7 +32,6 @@ export default function updateTests(setupData: ISetupData, api) {
   });
 
   test("update imageWithFourPeople", (t) => {
-    t.plan(3);
     const updatedRecord = {
       meta: {
         newProperty: "squirrel",
@@ -44,12 +43,12 @@ export default function updateTests(setupData: ISetupData, api) {
         t.equal(responseBody.username, imageWithFourPeople!.username);
         t.equal(responseBody.id, imageWithFourPeople!.id);
         t.equal(responseBody.meta.newProperty, updatedRecord.meta.newProperty);
+        t.end();
       })
       .catch(formatError);
   });
 
   test("get updated item", (t) => {
-    t.plan(3);
     const apiPath = getEndpointPath(imageWithFourPeople);
     api.get(setupData.apiUrl, apiPath)
       .then((responseBody: IImage) => {
@@ -68,6 +67,7 @@ export default function updateTests(setupData: ISetupData, api) {
           `existing meta width ${responseBody.meta.width} unaffected`,
         );
         t.ok(responseBody.tags!.includes(imageWithFourPeople!.tags![0]), "existing other props unaffected");
+        t.end();
       })
       .catch(formatError);
   });

--- a/test/functional/update.ts
+++ b/test/functional/update.ts
@@ -7,6 +7,8 @@ import getEndpointPath from "./getEndpointPath";
 export default function updateTests(setupData: ISetupData, api) {
   let imageWithFourPeople: IImage | undefined;
 
+  // should remove this - no updates really doable from api as wipes out existing meta
+
   test("query all to get img with four people", (t) => {
     const query: IQueryBody = {
       criteria: {

--- a/test/functional/update.ts
+++ b/test/functional/update.ts
@@ -53,11 +53,13 @@ export default function updateTests(setupData: ISetupData, api) {
       .then((responseBody: IImage) => {
         t.equal(responseBody.id, imageWithFourPeople!.id);
         t.equal(responseBody.meta.newProperty, "squirrel", "updated data");
+        t.ok(responseBody.meta.height, `meta height exists`);
         t.equal(
           responseBody.meta.height,
           imageWithFourPeople!.meta.height,
           `existing meta heigh ${responseBody.meta.height} unaffected`,
         );
+        t.ok(responseBody.meta.width, `meta width exists`);
         t.equal(
           responseBody.meta.width,
           imageWithFourPeople!.meta.width,

--- a/test/functional/update.ts
+++ b/test/functional/update.ts
@@ -34,6 +34,7 @@ export default function updateTests(setupData: ISetupData, api) {
   test("update imageWithFourPeople", (t) => {
     const updatedRecord = {
       meta: {
+        ...imageWithFourPeople!.meta,
         newProperty: "squirrel",
       },
     };

--- a/test/types.ts
+++ b/test/types.ts
@@ -2,6 +2,7 @@ import { ICreateBody } from "../fotos/types";
 
 export interface ISetupData {
   apiUrl: string;
+  collectionId: string;
   images: ITestImage[];
   records: ICreateBody[];
   startTime: number;

--- a/test/types.ts
+++ b/test/types.ts
@@ -5,6 +5,7 @@ export interface ISetupData {
   collectionId: string;
   images: ITestImage[];
   records: ICreateBody[];
+  region?: string;
   startTime: number;
   username: string;
   uniqueTag: string;


### PR DESCRIPTION
Add retry pattern to tests that rely on post request events being completed. Eg get indexes are correct only after the sequence; create -> thumb -> db save - > stream event - updateIndexes - write S3 object.
Move index update to seperate lambda
Add more traceMeta to trace invocations
Use Payload to ad traceMeta to GET (more to do).
Change indexes to delete 0 counts, as it's messing with the test, serves no value and will get bloated very quickly. Clean up to be done on this - eg log fields.