### PR TITLE
Towards fixing the indexes race condition

### DIFF
--- a/fotos/common/invokePutIndex.ts
+++ b/fotos/common/invokePutIndex.ts
@@ -4,24 +4,25 @@ import {
 import { INVOCATION_EVENT } from "../lib/constants";
 import lambda from "../lib/lambda";
 import {
-  IIndex,
+  IIndexUpdate, IPutIndexRequest,
 } from "../types";
 
-export function getInvokeUpdateParams(body: IIndex, traceMeta): InvocationRequest {
+export function getInvokeUpdateParams(indexUpdate: IIndexUpdate, traceMeta): InvocationRequest {
+  const body: IPutIndexRequest = {
+    indexUpdate,
+    traceMeta,
+  };
   return {
     FunctionName: `${process.env.LAMBDA_PREFIX}indexesUpdate`,
     InvocationType: INVOCATION_EVENT,
     LogType: "Tail",
     Payload: JSON.stringify({
-      body: JSON.stringify({
-        index: body,
-        traceMeta,
-      }),
+      body: JSON.stringify(body),
     }),
   };
 }
 
-export default function invokePutIndex(body: IIndex, traceMeta) {
-  const params = getInvokeUpdateParams(body, traceMeta);
+export default function invokePutIndex(indexUpdate: IIndexUpdate, traceMeta) {
+  const params = getInvokeUpdateParams(indexUpdate, traceMeta);
   return lambda.invoke(params).promise();
 }

--- a/fotos/indexes__test__.ts
+++ b/fotos/indexes__test__.ts
@@ -1,6 +1,8 @@
+import { DynamoDBRecord } from "aws-lambda";
 import * as test from "tape";
 import * as indexes from "./indexes";
-import { IIndex } from "./types";
+import { getIndexUpdates } from "./stream";
+import { IIndex, IIndexUpdate } from "./types";
 
 test("removeZeroCounts ", (t) => {
   const index: IIndex = {
@@ -18,4 +20,250 @@ test("removeZeroCounts ", (t) => {
   const result = indexes.removeZeroCounts(index);
   t.equal(result.tags.black, undefined, "0 index has been removed");
   t.end();
+});
+
+test("calculateUpdatedIndex - negative values", (t) => {
+  const existing: IIndex = {
+    people: {
+      barack: 1,
+    },
+    tags: {
+      yellow: 2,
+    },
+  };
+  const updates: IIndexUpdate = {
+    people: {
+      barack: -1,
+      fred: 2,
+    },
+    tags: {
+      yellow: -2,
+    },
+  };
+  const result = indexes.calculateUpdatedIndex(existing, updates);
+  t.deepEqual(result, {
+    people: {
+      barack: 0,
+      fred: 2,
+    },
+    tags: {
+      yellow: 0,
+    },
+  });
+
+  t.end();
+});
+
+test("calculateUpdatedIndex - no existing index", (t) => {
+  const errorIndex: IIndex = {
+    error: true,
+    people: {},
+    tags: {},
+  };
+  const updates: IIndexUpdate = {
+    people: {
+      emma: 1,
+      leona: 1,
+      wilma: 2,
+    },
+    tags: {
+      black: 0,
+      pink: 2,
+      yellow: 1,
+    },
+  };
+  const result = indexes.calculateUpdatedIndex(errorIndex, updates);
+  t.deepEqual(result, {
+    people: {
+      emma: 1,
+      leona: 1,
+      wilma: 2,
+    },
+    tags: {
+      black: 0,
+      pink: 2,
+      yellow: 1,
+    },
+  });
+  t.end();
+});
+
+test("getUpdatedIndexes - modifies existing index with just tags", (t) => {
+  const existing: IIndex = {
+    people: {},
+    tags: {
+      black: 4,
+      green: 7,
+      yellow: 1,
+    },
+  };
+  const updates: IIndexUpdate = {
+    people: {
+      emma: 1,
+      leona: 1,
+      wilma: 2,
+    },
+    tags: {
+      black: -1,
+      pink: 2,
+      yellow: 1,
+    },
+  };
+  const result = indexes.calculateUpdatedIndex(existing, updates);
+  t.deepEqual(result, {
+    people: {
+      emma: 1,
+      leona: 1,
+      wilma: 2,
+    },
+    tags: {
+      black: 3,
+      green: 7,
+      pink: 2,
+      yellow: 2,
+    },
+  });
+  t.end();
+});
+
+test("get image records indexes", (t) => {
+  const recordsRaw: DynamoDBRecord[] = [
+    {
+      awsRegion: "us-east-1",
+      dynamodb: {
+        ApproximateCreationDateTime: 1566962110,
+        Keys: {
+          id: { S: "9b1d5700-c8c3-11e9-bf5e-ab9eba55ceea" },
+          username: { S: "tester" },
+        },
+        OldImage: {
+          birthtime: { N: "1563448223924" },
+          createdAt: { N: "1566907807784" },
+          group: { S: "sosnowski-roberts-alpha" },
+          id: { S: "9b1d5700-c8c3-11e9-bf5e-ab9eba55ceea" },
+          img_key: { S: "tester/steve.jpg" },
+          img_thumb_key: { S: "tester/steve-thumbnail.jpg" },
+          meta: { M: { height: { N: "1448" }, width: { N: "1488" } } },
+          people: { L: [{ S: "9ca94e30-c8c3-11e9-a794-7524c255cd6f" }] },
+          tags: {
+            L: [
+              { S: "Human" },
+              { S: "Person" },
+              { S: "Glasses" },
+              { S: "Accessories" },
+              { S: "Accessory" },
+              { S: "Apparel" },
+              { S: "Clothing" },
+              { S: "Coat" },
+              { S: "Suit" },
+              { S: "Overcoat" },
+            ],
+          },
+          traceMeta: {
+            M: {
+              parentId: { S: "03a4d4b0-c8c4-11e9-aa07-0d71283ce829" },
+              traceId: { S: "03a4d4b1-c8c4-11e9-aa07-0d71283ce829" },
+            },
+          },
+          updatedAt: { N: "1566907982467" },
+          userIdentityId: {
+            S: "us-east-1:e2824167-1682-4bdb-a285-f91e97e4cb03",
+          },
+          username: { S: "tester" },
+        },
+        SequenceNumber: "35734900000000002324267854",
+        SizeBytes: 1778,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+      eventID: "560a1933c812726f38fec9f05158b2b3",
+      eventName: "REMOVE",
+      eventSource: "aws:dynamodb",
+      eventSourceARN:
+        "arn:aws:dynamodb:us-east-1:366399188066:table/fotopia-web-app-alpha/stream/2019-08-20T12:25:36.318",
+      eventVersion: "1.1",
+    },
+  ];
+  const existingIndex: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
+    },
+    tags: {
+      Accessories : 1,
+      Accessory : 1,
+      Apparel : 1,
+      Clothing: 1,
+      Coat: 1,
+      Glasses: 1,
+      Human: 1,
+      Overcoat: 1,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+  const updates: IIndexUpdate = getIndexUpdates(recordsRaw);
+
+  const result = indexes.calculateUpdatedIndex(existingIndex, updates);
+  t.deepEqual(result, {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
+    },
+    tags: {
+      Accessories : 0,
+      Accessory : 0,
+      Apparel : 0,
+      Clothing: 0,
+      Coat: 0,
+      Glasses: 0,
+      Human: 0,
+      Overcoat: 0,
+      Person: 0,
+      Suit: 0,
+    },
+  });
+  t.end();
+});
+
+test("getModifiedIndexItems", (t) => {
+  const existing: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
+    },
+    tags: {
+      Accessories : 1,
+      Accessory : 1,
+      Apparel : 1,
+      Clothing: 1,
+      Coat: 1,
+      Glasses: 1,
+      Human: 1,
+      Overcoat: 1,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+  const updated: IIndex = {
+    people: {
+      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
+    },
+    tags: {
+      Accessories : 0,
+      Accessory : 0,
+      Apparel : 0,
+      Clothing: 0,
+      Coat: 0,
+      Glasses: 0,
+      Human: 2,
+      Overcoat: 0,
+      Person: 1,
+      Suit: 1,
+    },
+  };
+
+  const resultPeople = indexes.getModifiedIndexItems(existing.people, updated.people);
+  const resultTags = indexes.getModifiedIndexItems(existing.tags, updated.tags);
+
+  t.equal(resultPeople.length, 1, `${resultPeople.length} modified people`);
+  t.equal(resultTags.length, 8, `${resultTags.length} modified tags`);
+  t.end();
+
 });

--- a/fotos/stream__test__.ts
+++ b/fotos/stream__test__.ts
@@ -98,8 +98,8 @@ const records: DynamoDBRecord[] = [{
   eventName: "MODIFY",
 }];
 
-test("parseIndexes - adds all tags and people for inserted record ", (t) => {
-  const result = stream.parseIndexes([records[0]]);
+test("getIndexUpdates - adds all tags and people for inserted record ", (t) => {
+  const result = stream.getIndexUpdates([records[0]]);
   t.deepEqual(result, {
     people: {
       emma: 1,
@@ -114,8 +114,8 @@ test("parseIndexes - adds all tags and people for inserted record ", (t) => {
   t.end();
 });
 
-test("parseIndexes - adds all new tags and people and removes old for modified record ", (t) => {
-  const result = stream.parseIndexes([records[1]]);
+test("getIndexUpdates - adds all new tags and people and removes old for modified record ", (t) => {
+  const result = stream.getIndexUpdates([records[1]]);
   t.deepEqual(result, {
     people: {
       wilma: 1,
@@ -128,8 +128,8 @@ test("parseIndexes - adds all new tags and people and removes old for modified r
   t.end();
 });
 
-test("parseIndexes - handles both an insert and modify record", (t) => {
-  const result = stream.parseIndexes(records);
+test("getIndexUpdates - handles both an insert and modify record", (t) => {
+  const result = stream.getIndexUpdates(records);
   t.deepEqual(result, {
     people: {
       emma: 1,
@@ -140,210 +140,6 @@ test("parseIndexes - handles both an insert and modify record", (t) => {
       black: -1,
       pink: 2,
       yellow: 1,
-    },
-  });
-  t.end();
-});
-
-test("updateCounts - negative values", (t) => {
-  const existing = {
-    people: {
-      barack: 1,
-    },
-    tags: {
-      yellow: 2,
-    },
-  };
-  const updates = {
-    people: {
-      barack: -1,
-      fred: 2,
-    },
-    tags: {
-      yellow: -2,
-    },
-  };
-  const result = stream.updateCounts(existing, updates);
-  t.deepEqual(result, {
-    people: {
-      barack: 0,
-      fred: 2,
-    },
-    tags: {
-      yellow: 0,
-    },
-  });
-
-  t.end();
-});
-
-test("getUpdatedIndexes - no existing index", (t) => {
-  const errorIndex: IIndex = {
-    error: true,
-    people: {},
-    tags: {},
-  };
-  const result = stream.getUpdatedIndexes(errorIndex, records);
-  t.deepEqual(result, {
-    people: {
-      emma: 1,
-      leona: 1,
-      wilma: 2,
-    },
-    tags: {
-      black: 0,
-      pink: 2,
-      yellow: 1,
-    },
-  });
-  t.end();
-});
-
-test("getUpdatedIndexes - modifies existing index with just tags", (t) => {
-  const existing: IIndex = {
-    people: {},
-    tags: {
-      black: 4,
-      green: 7,
-      yellow: 1,
-    },
-  };
-  const result = stream.getUpdatedIndexes(existing, records);
-  t.deepEqual(result, {
-    people: {
-      emma: 1,
-      leona: 1,
-      wilma: 2,
-    },
-    tags: {
-      black: 3,
-      green: 7,
-      pink: 2,
-      yellow: 2,
-    },
-  });
-  t.end();
-});
-
-test("getUpdatedIndexes - modifies existing index with tags and people", (t) => {
-  const existing = {
-    people: {
-      emma: 2,
-      geoff: 3,
-    },
-    tags: {
-      black: 4,
-      yellow: 1,
-    },
-  };
-  const result = stream.getUpdatedIndexes(existing, records);
-  t.deepEqual(result, {
-    people: {
-      emma: 3,
-      geoff: 3,
-      leona: 1,
-      wilma: 2,
-    },
-    tags: {
-      black: 3,
-      pink: 2,
-      yellow: 2,
-    },
-  });
-  t.end();
-});
-
-test("get image records indexes", (t) => {
-  const recordsRaw: DynamoDBRecord[] = [
-    {
-      awsRegion: "us-east-1",
-      dynamodb: {
-        ApproximateCreationDateTime: 1566962110,
-        Keys: {
-          id: { S: "9b1d5700-c8c3-11e9-bf5e-ab9eba55ceea" },
-          username: { S: "tester" },
-        },
-        OldImage: {
-          birthtime: { N: "1563448223924" },
-          createdAt: { N: "1566907807784" },
-          group: { S: "sosnowski-roberts-alpha" },
-          id: { S: "9b1d5700-c8c3-11e9-bf5e-ab9eba55ceea" },
-          img_key: { S: "tester/steve.jpg" },
-          img_thumb_key: { S: "tester/steve-thumbnail.jpg" },
-          meta: { M: { height: { N: "1448" }, width: { N: "1488" } } },
-          people: { L: [{ S: "9ca94e30-c8c3-11e9-a794-7524c255cd6f" }] },
-          tags: {
-            L: [
-              { S: "Human" },
-              { S: "Person" },
-              { S: "Glasses" },
-              { S: "Accessories" },
-              { S: "Accessory" },
-              { S: "Apparel" },
-              { S: "Clothing" },
-              { S: "Coat" },
-              { S: "Suit" },
-              { S: "Overcoat" },
-            ],
-          },
-          traceMeta: {
-            M: {
-              parentId: { S: "03a4d4b0-c8c4-11e9-aa07-0d71283ce829" },
-              traceId: { S: "03a4d4b1-c8c4-11e9-aa07-0d71283ce829" },
-            },
-          },
-          updatedAt: { N: "1566907982467" },
-          userIdentityId: {
-            S: "us-east-1:e2824167-1682-4bdb-a285-f91e97e4cb03",
-          },
-          username: { S: "tester" },
-        },
-        SequenceNumber: "35734900000000002324267854",
-        SizeBytes: 1778,
-        StreamViewType: "NEW_AND_OLD_IMAGES",
-      },
-      eventID: "560a1933c812726f38fec9f05158b2b3",
-      eventName: "REMOVE",
-      eventSource: "aws:dynamodb",
-      eventSourceARN:
-        "arn:aws:dynamodb:us-east-1:366399188066:table/fotopia-web-app-alpha/stream/2019-08-20T12:25:36.318",
-      eventVersion: "1.1",
-    },
-  ];
-  const existingIndex: IIndex = {
-    people: {
-      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
-    },
-    tags: {
-      Accessories : 1,
-      Accessory : 1,
-      Apparel : 1,
-      Clothing: 1,
-      Coat: 1,
-      Glasses: 1,
-      Human: 1,
-      Overcoat: 1,
-      Person: 1,
-      Suit: 1,
-    },
-  };
-  const result = stream.getUpdatedIndexes(existingIndex, recordsRaw);
-
-  t.deepEqual(result, {
-    people: {
-      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
-    },
-    tags: {
-      Accessories : 0,
-      Accessory : 0,
-      Apparel : 0,
-      Clothing: 0,
-      Coat: 0,
-      Glasses: 0,
-      Human: 0,
-      Overcoat: 0,
-      Person: 0,
-      Suit: 0,
     },
   });
   t.end();
@@ -395,49 +191,4 @@ test("getZeroCount", (t) => {
   t.equal(resultUpdatedPeople, 1, `${resultUpdatedPeople}  zero counts in updated people`);
   t.equal(resultUpdatedTags, 10, `${resultUpdatedTags}  zero counts in updated tags`);
   t.end();
-});
-
-test("getModifiedIndexItems", (t) => {
-  const existing: IIndex = {
-    people: {
-      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 1,
-    },
-    tags: {
-      Accessories : 1,
-      Accessory : 1,
-      Apparel : 1,
-      Clothing: 1,
-      Coat: 1,
-      Glasses: 1,
-      Human: 1,
-      Overcoat: 1,
-      Person: 1,
-      Suit: 1,
-    },
-  };
-  const updated: IIndex = {
-    people: {
-      "9ca94e30-c8c3-11e9-a794-7524c255cd6f": 0,
-    },
-    tags: {
-      Accessories : 0,
-      Accessory : 0,
-      Apparel : 0,
-      Clothing: 0,
-      Coat: 0,
-      Glasses: 0,
-      Human: 2,
-      Overcoat: 0,
-      Person: 1,
-      Suit: 1,
-    },
-  };
-
-  const resultPeople = stream.getModifiedIndexItems(existing.people, updated.people);
-  const resultTags = stream.getModifiedIndexItems(existing.tags, updated.tags);
-
-  t.equal(resultPeople.length, 1, `${resultPeople.length} modified people`);
-  t.equal(resultTags.length, 8, `${resultTags.length} modified tags`);
-  t.end();
-
 });

--- a/fotos/types/stream.ts
+++ b/fotos/types/stream.ts
@@ -6,6 +6,13 @@ export interface IIndex {
   error?: boolean;
 }
 
+// same shape as IIndex but calling it out as a
+// different type to flag it wil have relative values that reflect the updates
+export interface IIndexUpdate {
+  people: IIndexDictionary;
+  tags: IIndexDictionary;
+}
+
 export interface IIndexDictionary {
   [name: string]: number;
 }
@@ -22,6 +29,6 @@ export interface IIndexFields {
 }
 
 export interface IPutIndexRequest {
-  index: IIndex;
+  indexUpdate: IIndexUpdate;
   traceMeta: ITraceMeta;
 }

--- a/test/functional.ts
+++ b/test/functional.ts
@@ -17,15 +17,12 @@ config();
 export default function(auth: any, api: any, upload: any) {
   setup(auth)
     .then((setupData: any) => {
-      // to check - there may be a prob when I delete the
-      // index and people objects, this adds time and so
-      // tests that check for people dont pass...?
       deleteAllTestData(setupData, api);
       uploadTests(setupData, upload);
       createTests(setupData, api);
       queryTests(setupData, api);
-      indexesTests(setupData, api);
       getTests(setupData, api);
+      indexesTests(setupData, api);
       updateTests(setupData, api);
       peopleTests(setupData, api);
       deleteTests(setupData, api);

--- a/test/functional/get.ts
+++ b/test/functional/get.ts
@@ -5,8 +5,11 @@ import formatError from "./formatError";
 import getEndpointPath from "./getEndpointPath";
 
 export default function getTests(setupData: ISetupData, api: any) {
-  let imageWithFourPeople: IImage | undefined;
-  test("query all to get an id", (t) => {
+
+  const retryStrategy = [300, 500, 1000, 2000, 5000];
+  let imagesWithFourPeople: IImage[];
+  let imagesWithOnePerson: IImage[];
+  test("query all to get the test image ids", (t) => {
     t.plan(2);
 
     const query: IQueryBody = {
@@ -23,21 +26,60 @@ export default function getTests(setupData: ISetupData, api: any) {
       body: query,
     })
       .then((responseBody: IImage[]) => {
-        t.ok(responseBody.find((rec) => rec.img_key === setupData.records[0].img_key), "image one found");
-        imageWithFourPeople = responseBody.find((rec) => rec.img_key === setupData.records[1].img_key);
-        t.ok(imageWithFourPeople, "image with four people found");
+        imagesWithOnePerson = responseBody.filter((rec) => rec.img_key === setupData.records[0].img_key);
+        t.ok(imagesWithOnePerson.length > 0, "image(s) with one  personfound");
+        imagesWithFourPeople = responseBody.filter((rec) => rec.img_key === setupData.records[1].img_key);
+        t.ok(imagesWithFourPeople.length > 0, "image(s) with four people found");
       })
       .catch(formatError);
   });
 
-  test("get an item", (t) => {
-    t.plan(2);
-    const apiPath = getEndpointPath(imageWithFourPeople);
-    api.get(setupData.apiUrl, apiPath)
-      .then((responseBody: IImage) => {
-        t.equal(responseBody.img_key, imageWithFourPeople!.img_key, "response has same img_key");
-        t.equal(responseBody.id, imageWithFourPeople!.id, "response has same id");
-      })
-      .catch(formatError);
+  test("get items, retry until the record has the correct people count - shows the event chain is completed", (t) => {
+    const testImages = [...imagesWithOnePerson, ...imagesWithFourPeople];
+
+    testImages.forEach((image, idx, arr) => {
+      let retryCount = 0;
+      const retryableTest = {
+        args: [setupData.apiUrl, getEndpointPath(image)],
+        fn: api.get,
+      };
+      const retryableTestThen = (responseBody: IImage) => {
+        if (!responseBody.people || responseBody.people.length === 0) {
+          if (retryCount < retryStrategy.length) {
+            setTimeout(() => {
+              retryCount++;
+              t.comment(`Retry # ${retryCount} after ${retryStrategy[retryCount - 1]}ms`);
+              retry();
+            }, retryStrategy[retryCount]);
+          } else {
+            t.fail(`Failed - ${responseBody.img_key} people: ${responseBody.people} after ${retryCount} retries`);
+            if (idx === arr.length - 1) {
+              t.end();
+            }
+          }
+        } else {
+          const expectedLength = responseBody.img_key === imagesWithFourPeople[0].img_key ? 4 : 1;
+          t.equal(
+            responseBody.people.length,
+            expectedLength,
+            `image (${
+              responseBody.img_key
+            }) has people length of ${
+              responseBody.people.length
+            }`,
+          );
+          if (idx === arr.length - 1) {
+            t.end();
+          }
+        }
+      };
+      const retry = () => {
+        retryableTest.fn.apply(this, retryableTest.args)
+          .then(retryableTestThen)
+          .catch(formatError);
+      };
+
+      retry();
+    });
   });
 }

--- a/test/functional/indexes.ts
+++ b/test/functional/indexes.ts
@@ -23,7 +23,7 @@ export default function indexesTests(setupData, api) {
     api.post(setupData.apiUrl, "/query", {
       body: query,
     })
-      .then((responseBody) => {
+      .then((responseBody: IImage[]) => {
         t.equal(responseBody.length >= 2, true, "at least two images in env");
         testImages = responseBody.filter((img) => img.img_key === setupData.records[1].img_key ||
           img.img_key === setupData.records[0].img_key );
@@ -45,6 +45,12 @@ export default function indexesTests(setupData, api) {
       args: [setupData.apiUrl, "/indexes"],
       fn: api.get,
     };
+
+    const testImgTagsAndPeopleIds = testImages.map((i) => ({
+      img_key: i.img_key,
+      people: i.people,
+      tags: i.tags,
+    }));
     const retryableTestThen = (responseBody: IIndex) => {
       const changes = createIndexChangeTable(MODES.ADD, testImages, existingIndexes, responseBody);
       if (changes.valid.people.length + changes.valid.tags.length > 0) {
@@ -61,7 +67,8 @@ export default function indexesTests(setupData, api) {
             changes.valid.people.length
           } incorrectly adjusted people after ${retryCount} retries. Fail details: \n${
             JSON.stringify(changes.valid, null, 2)
-          }`);
+          } testImgTagsAndPeopleIds: ${JSON.stringify(testImgTagsAndPeopleIds)}
+          responseBody: ${JSON.stringify(responseBody)}`);
           t.end();
         }
       } else {


### PR DESCRIPTION
The indexes update can be lost with the use of S3 as these unserialized transactions have a lot of scope (1 sec at p99) to be concurrent. Moving the read/write to the same lambda will help but most likely I'll need to add an SQS queue and use a dynamodb table for the index data